### PR TITLE
chore: maybe squeeze out a bit more read performance from node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phcode/fs",
   "description": "Phoenix virtual file system over filer/ browser fs access/ tauri / phoenix web socket APIs",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "keywords": [
     "phoenix",
     "browser",


### PR DESCRIPTION
fs.promises.readFile is 40% slower than fs.readFile 
> Though we noted only minor variations is our test.

but fsNormal.readFile was faster most of the time though only by very few 10's of MS. And at times the other one was faster too. But most of the time, the non-promise impl was faster.

Leaving no quick-fix performance on the table, so we moved to this impl as phoenix-fs lib is a core fs lib for the browser and every bit of performance counts at this time to improve ui responsiveness.

 https://github.com/nodejs/node/issues/37583